### PR TITLE
Made Lynians race able to receave egg blessings

### DIFF
--- a/1.5/Patches/MSSG_LyniansXeno_Patch.xml
+++ b/1.5/Patches/MSSG_LyniansXeno_Patch.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	 <Operation Class="PatchOperationInsert">
+                <xpath>Defs/AlienRace.ThingDef_AlienRace/alienRace/raceRestriction[onlyUseRaceRestrictedXenotypes="true"]/whiteXenotypeList/li[text()="Sanguophage"]</xpath>
+				<order>Append</order>
+                <value>
+					    <li>MSSG_Eggcubator</li>
+						<li>MSSG_Eggblessed</li>
+                </value>
+	 </Operation>
+</Patch>


### PR DESCRIPTION
This patch fixes the issue with certain races being unable to gain the EggBleesed and Eggcubator xenotype.

This patch addresses the issue and makes them able to gain it.

If there are any other HAR races in Sams pack i imagine this code could be reused to implement support for it.
![image](https://github.com/user-attachments/assets/60f15897-000f-431a-b853-531f53a533bb)
Note the modpack i'm using in this screenshot does not contain any other gene mods.

Anyway have a nice day/night.