### PR TITLE
Allowed Goldilox to be used in caravans

### DIFF
--- a/1.5/Patches/MSSG_Goldilox_PackAnimal.xml
+++ b/1.5/Patches/MSSG_Goldilox_PackAnimal.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="DA_Goldilox"]/race</xpath>
+                <value>
+					        <packAnimal>true</packAnimal> <!-- Allows Goldilox to carry items in a caravan -->
+                </value>
+   </Operation>
+</Patch>


### PR DESCRIPTION
Goldilox can now carry items within a caravan.
They look like a creature that would carry tons of random junk.
Not much of a bug but just a QOL change to a mod.

Hope this little patch helps