### PR TITLE
Patched gold to be stronger when used as item stuff

### DIFF
--- a/1.5/Patches/MSSG_Stronger_Real_Gold.xml
+++ b/1.5/Patches/MSSG_Stronger_Real_Gold.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationReplace">
+                <xpath>Defs/ThingDef[defName="Gold"]/stuffProps/statFactors/MaxHitPoints</xpath>
+                <value>
+					        <MaxHitPoints>1</MaxHitPoints> <!-- Makes gold slightly stronger -->
+                </value>
+   </Operation>
+</Patch>


### PR DESCRIPTION
Since gold is the central focus of this modpack why not make gold stronger? Having a 90 HP marine helemet does not sound fun.

Gold now has the same max hitpoint value as vanilla steel (1.0) So now marine armor thats crafted from gold will be as strong as if it was not made from gold in the first place (Vanilla HP value).

This image will show a comparison of the HP values before and after the patch

![image](https://github.com/user-attachments/assets/21fd1976-6336-48b1-b70e-6479ac32aa60)

BIG MASSIVE WARNING!!!!!

If implemented make a backup of your save since anything already made from gold will stay at whatever HP it had before the patch took effect so some items may apear to be more damage then they were before. I recormend on any item to set the HP amount to whatever percentage that it had before. you dont have to.


Hope this patch helps.
